### PR TITLE
mark files flagged as fixed position

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "romimg.h": "c"
+    }
+}

--- a/src/main.c
+++ b/src/main.c
@@ -26,7 +26,15 @@ static void DisplayROMImgDetails(const ROMIMG *ROMImg)
     for (i = 0, file = ROMImg->files, TotalSize = 0; i < ROMImg->NumFiles; TotalSize += file->RomDir.size, i++, file++) {
         strncpy(filename, file->RomDir.name, sizeof(filename) - 1);
         filename[sizeof(filename) - 1] = '\0';
-        printf(GREEN"%-10s"DEFCOL"\t%u\n", filename, file->RomDir.size);
+        struct ExtInfoFieldEntry* S = (struct ExtInfoFieldEntry*)file->ExtInfoData;
+        int isFixed = 0;
+        for(int x=0; x<file->RomDir.ExtInfoEntrySize; x++, S++) // parse all extinfo entries. look for the fixed property
+            if (!isFixed) isFixed = (S->type == EXTINFO_FIELD_TYPE_FIXED);
+        printf("%s%-10s"DEFCOL"\t%u\n", 
+            isFixed ? YELBOLD : GREEN,
+            filename,
+            file->RomDir.size
+        );
     }
 
     printf("\nTotal size: %u bytes.\n", TotalSize);

--- a/src/romimg.c
+++ b/src/romimg.c
@@ -123,7 +123,7 @@ static int GetExtInfoStat(const struct ROMImgStat *ImageStat, struct RomDirFileF
 			}
 
 			offset += sizeof(struct ExtInfoFieldEntry);
-		} else if (ExtInfoEntry->type == EXTINFO_FIELD_TYPE_NULL) {
+		} else if (ExtInfoEntry->type == EXTINFO_FIELD_TYPE_FIXED) {
 			result = 0;
 			break;
 		} else {


### PR DESCRIPTION
Files Wich are marked as fixed position will highlight on yellow instead of green

Those files are most likely expected at their offset by the console bootstrap program